### PR TITLE
OP-114: Adding GPU Support to the predict endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests==2.23.0
 gunicorn
 spacy>=3.0.0,<4.0.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-numpy~=1.22.3
+numpy~=1.21.6
 scikit-learn~=1.0.2
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.11.0+cu113
+torch==1.11.0


### PR DESCRIPTION
Exposing a new parameter to select the device to use for the `/predict` endpoint. This can be configured as an environment variable called `CPU_GPU_DEVICE`. If set to -1, CPU will be used.

NOTE: I've reverted some changes to the `requirements.txt` as the merged code has some changes that it seems they haven't been tested as a image or within a cluster. For example, the numpy required version was not compatible w/ Python 3.7, which is the base image used. Going forward it is better to test those well in branches, as this repo is used by Fuse and OP and possible other customers.